### PR TITLE
Use babel with react preset instead of JSX

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -3,9 +3,7 @@
 function react() {
   var build = require('./index');
 
-  var tree = build('./test/fixture/');
-
-  return build(tree, {extensions: ['js'], transform: { harmony: true }});
+  return build('./test/fixture/', { extensions: ['js', 'jsx'] });
 }
 
 module.exports = react();

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ ReactFilter.prototype.targetExtension = 'js';
 ReactFilter.prototype.processString = function (string) {
   var result = babel.transform(string, {
     babelrc: false,
-    presets: ['env', 'react']
+    presets: ['react']
   }).code;
 
   return result;

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var Filter = require('broccoli-filter');
 var babel = require('babel-core');
+var reactPreset = require('babel-preset-react');
 
 module.exports = ReactFilter;
 
@@ -26,7 +27,7 @@ ReactFilter.prototype.targetExtension = 'js';
 ReactFilter.prototype.processString = function (string) {
   var result = babel.transform(string, {
     babelrc: false,
-    presets: ['react']
+    presets: [reactPreset]
   }).code;
 
   return result;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Filter = require('broccoli-filter');
-var react = require('react-tools').transform;
+var babel = require('babel-core');
 
 module.exports = ReactFilter;
 
@@ -15,7 +15,6 @@ function ReactFilter (inputTree, options) {
 
   this.inputTree = inputTree;
   this.options = options || {};
-  this.transform = this.options.transform || {};
   if (this.options.extensions) {
     this.extensions = options.extensions;
   }
@@ -25,7 +24,10 @@ ReactFilter.prototype.extensions = ['jsx'];
 ReactFilter.prototype.targetExtension = 'js';
 
 ReactFilter.prototype.processString = function (string) {
-  var result = react(string, this.transform);
+  var result = babel.transform(string, {
+    babelrc: false,
+    presets: ['env', 'react']
+  }).code;
 
   return result;
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   ],
   "dependencies": {
     "babel-core": "^6.24.1",
-    "babel-preset-env": "^1.5.1",
     "babel-preset-react": "^6.24.1",
     "broccoli-filter": "^0.1.11"
   },

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "description": "Convert Facebook React JSX files to JS",
   "version": "0.7.1",
   "author": "Edd Hannay <site@edd.fm>",
-  "contributors": [{
-    "name": "Rick Harrison",
-    "email": "r@rickharrison.me"
-  }],
+  "contributors": [
+    {
+      "name": "Rick Harrison",
+      "email": "r@rickharrison.me"
+    }
+  ],
   "main": "index.js",
   "license": "MIT",
   "repository": {
@@ -20,8 +22,10 @@
     "compile"
   ],
   "dependencies": {
-    "broccoli-filter": "^0.1.11",
-    "react-tools": "^0.13.1"
+    "babel-core": "^6.24.1",
+    "babel-preset-env": "^1.5.1",
+    "babel-preset-react": "^6.24.1",
+    "broccoli-filter": "^0.1.11"
   },
   "devDependencies": {
     "broccoli": "^0.13.3",

--- a/test/expected/harmony.js
+++ b/test/expected/harmony.js
@@ -1,11 +1,19 @@
 /*jslint indent: 2, node: true, nomen: true, browser: true*/
 /*global React */
 'use strict';
-var $__0=     require('../js/foo'),bar=$__0.bar,baz=$__0.baz;
-module.exports = React.createClass({displayName: "exports",
-  render: function () {
-    return (
-      React.createElement("h1", null, "Output")
+
+var _require = require('../js/foo'),
+    bar = _require.bar,
+    baz = _require.baz;
+
+module.exports = React.createClass({
+  displayName: 'exports',
+
+  render: function render() {
+    return React.createElement(
+      'h1',
+      null,
+      'Output'
     );
   }
 });

--- a/test/expected/harmony.js
+++ b/test/expected/harmony.js
@@ -2,14 +2,11 @@
 /*global React */
 'use strict';
 
-var _require = require('../js/foo'),
-    bar = _require.bar,
-    baz = _require.baz;
-
+var { bar, baz } = require('../js/foo');
 module.exports = React.createClass({
   displayName: 'exports',
 
-  render: function render() {
+  render: function () {
     return React.createElement(
       'h1',
       null,

--- a/test/expected/test.js
+++ b/test/expected/test.js
@@ -1,10 +1,15 @@
 /*jslint indent: 2, node: true, nomen: true, browser: true*/
 /*global React */
 'use strict';
-module.exports = React.createClass({displayName: "exports",
-  render: function () {
-    return (
-      React.createElement("h1", null, "Output")
+
+module.exports = React.createClass({
+  displayName: 'exports',
+
+  render: function render() {
+    return React.createElement(
+      'h1',
+      null,
+      'Output'
     );
   }
 });

--- a/test/expected/test.js
+++ b/test/expected/test.js
@@ -5,7 +5,7 @@
 module.exports = React.createClass({
   displayName: 'exports',
 
-  render: function render() {
+  render: function () {
     return React.createElement(
       'h1',
       null,


### PR DESCRIPTION
[`react-tools` has been deprecated](https://facebook.github.io/react/blog/2015/06/12/deprecating-jstransform-and-react-tools.html) for quite some time. It still works for v15 but there will be some warnings (in red) when spread operator is used.

This PR migrates to `babel`. Also, it updates the responsibility of `broccoli-react` to only transpile JSX. That means it will preserve any other ES2015 features. For ES2015 features, it should be go through [`broccoli-babel-transpiler`](https://github.com/babel/broccoli-babel-transpiler) or `ember-cli-babel`